### PR TITLE
fix: auth services, roles map error 

### DIFF
--- a/generators/app/templates/app/services/AuthService.ts
+++ b/generators/app/templates/app/services/AuthService.ts
@@ -45,6 +45,8 @@ export interface JWTPayload {
 
 class AuthService {
   public createToken(user: User, type: string): Token {
+    if (!user?.roles) throw new ReferenceError("roles was not included into user.");
+
     const expiryUnit: moment.unitOfTime.DurationConstructor =
       config.jwt[type].expiry.unit;
     const expiryLength: number = config.jwt[type].expiry.length;


### PR DESCRIPTION
### Type of PR
- [ ] Feature
- [x] Bugfix
- [ ] Hotfix
- [ ] Chore

### Merge strategy
- [x] Squash (default)
- [ ] Merge commit (branch merges, usually used for merges to master)
- [ ] Rebase (preserve individual commits without merge commit)

### Purpose
> when createToken function is called and the User sequalize object doesn't include the roles sequalize object, it is not possible to run the function because it can not make the map method of an undefined property role, this small code handle the error when this occurs. So it will throw an error when undefined.map occurs.
### Relevant PR's

https://github.com/LuisGerar321/flugzeug-generator/pull/2