### PR TITLE
fix: added async line to auth generator in order to avoid issues with…

### DIFF
--- a/generators/app/templates/app/controllers/v1/Auth.ts
+++ b/generators/app/templates/app/controllers/v1/Auth.ts
@@ -609,7 +609,7 @@ export class AuthController extends BaseController {
       });
   }
 
-  private handleResetEmail(email: string): Promise<any> {
+  private async handleResetEmail(email: string): Promise<any> {
     return User.findOne({
       where: { email: email },
       include: [{ model: Profile, as: "profile" }],

--- a/generators/app/templates/app/controllers/v1/Auth.ts
+++ b/generators/app/templates/app/controllers/v1/Auth.ts
@@ -292,46 +292,44 @@ export class AuthController extends BaseController {
   */
   @Post("/reset")
   @Middlewares([validateBody(AuthRegisterSchema)])
-  resetPost = (req: Request, res: Response) => {
+  resetPost = async (req: Request, res: Response) => {
     // Validate if case 2
     const token: string = req.body.token;
     const password: string = req.body.password;
 
     if (!_.isUndefined(token) && !_.isUndefined(password)) {
-      return this.handleResetChPass(token, password)
-        .then((credentials) => BaseController.ok(res, credentials))
-        .catch((err) => {
-          log.error(err);
-          if (err.error == "badRequest")
-            return BaseController.badRequest(res, err.msg);
-          if (err.error == "notFound")
-            return BaseController.notFound(res, err.msg);
-          if (err.error == "serverError")
-            return BaseController.serverError(res, err.msg);
-          return BaseController.serverError(res);
-        });
+      try {
+        const resetEmail = await this.handleResetChPass(token, password);
+      } catch (err) {
+        log.error(err);
+        if (err.error == "badRequest")
+          return BaseController.badRequest(res, err.msg);
+        if (err.error == "notFound")
+          return BaseController.notFound(res, err.msg);
+        if (err.error == "serverError")
+          return BaseController.serverError(res, err.msg);
+        return BaseController.serverError(res);        
+      }
     }
 
     // Validate case 1
     const email: string = req.body.email;
     if (!_.isUndefined(email)) {
-      return this.handleResetEmail(email)
-        .then((info) => {
-          log.info(info);
-          BaseController.ok(res);
-        })
-        .catch((err) => {
-          log.error(err);
-          if (err.error == "badRequest")
-            return BaseController.badRequest(res, err.msg);
-          if (err.error == "notFound")
-            return BaseController.notFound(res, err.msg);
-          if (err.error == "serverError")
-            return BaseController.serverError(res, err.msg);
-          return BaseController.serverError(res);
-        });
-    }
+      try {
+        const resetEmail = await this.handleResetEmail(email);
+        log.info(resetEmail);
+        return BaseController.ok(res);
+      } catch (err) {
+        log.error(err);
+        if (err.error == "badRequest") return BaseController.badRequest(res, err.msg);
+        
+        if (err.error == "notFound") return BaseController.notFound(res, err.msg);
+        
+        if (err.error == "serverError") return BaseController.serverError(res, err.msg);
 
+        return BaseController.serverError(res);
+      }
+    }
     return BaseController.badRequest(res);
   };
 
@@ -609,31 +607,23 @@ export class AuthController extends BaseController {
       });
   }
 
+<<<<<<< Updated upstream
   private handleResetEmail(email: string): PromiseLike<any> {
     return User.findOne({
+=======
+  private async handleResetEmail(email: string): Promise<any> {
+    const user = await User.findOne({
+>>>>>>> Stashed changes
       where: { email: email },
-      include: [{ model: Profile, as: "profile" }],
+      include: [{ model: Profile, as: "profile" }],     
     })
-      .then((user) => {
-        if (!user) {
-          throw { error: "notFound", msg: "Email not found" };
-        }
-        // Create reset token
-        const token = this.createToken(user, "reset");
-        return {
-          token: token.token,
-          email: email,
-          name: user.name,
-          user: user,
-        };
-      })
-      .then((emailInfo) => {
-        return this.sendEmailNewPassword(
-          emailInfo.user,
-          emailInfo.token,
-          emailInfo.name,
-        );
-      });
+
+    if (!user) {
+      throw { error: "notFound", msg: "Email not found" };
+    }
+
+    const token = this.createToken(user, "reset");
+    return this.sendEmailNewPassword(user, token.token, user.name);
   }
 
   private handleResetChPass(

--- a/generators/app/templates/app/controllers/v1/Auth.ts
+++ b/generators/app/templates/app/controllers/v1/Auth.ts
@@ -607,13 +607,8 @@ export class AuthController extends BaseController {
       });
   }
 
-<<<<<<< Updated upstream
-  private handleResetEmail(email: string): PromiseLike<any> {
-    return User.findOne({
-=======
   private async handleResetEmail(email: string): Promise<any> {
     const user = await User.findOne({
->>>>>>> Stashed changes
       where: { email: email },
       include: [{ model: Profile, as: "profile" }],     
     })

--- a/generators/app/templates/app/controllers/v1/Auth.ts
+++ b/generators/app/templates/app/controllers/v1/Auth.ts
@@ -609,7 +609,7 @@ export class AuthController extends BaseController {
       });
   }
 
-  private async handleResetEmail(email: string): Promise<any> {
+  private handleResetEmail(email: string): PromiseLike<any> {
     return User.findOne({
       where: { email: email },
       include: [{ model: Profile, as: "profile" }],


### PR DESCRIPTION
When the auth controller template is generated it shows an issue with the type returned with the promise.Types. It was solved by adding the async keyword before the function handleResetEmail.

<img width="848" alt="image" src="https://user-images.githubusercontent.com/62272090/175422260-4165f147-612e-458e-9af0-b6dcd9a4c289.png">


![image](https://user-images.githubusercontent.com/62272090/175419604-52d198bb-2cd8-449a-9b06-912178e99702.png)
