### PR TITLE
fix: jwtblacklist extends from model

### DIFF
--- a/generators/app/templates/app/models/JWTBlacklist.ts
+++ b/generators/app/templates/app/models/JWTBlacklist.ts
@@ -1,10 +1,10 @@
-import { Table, Column, DataType } from "sequelize-typescript";
+import { Table, Column, DataType, Model } from "sequelize-typescript";
 import { BaseModel } from "flugzeug";
 
 @Table({
   tableName: "jwtblacklist",
 })
-export class JWTBlacklist extends BaseModel<JWTBlacklist> {
+export class JWTBlacklist extends Model {
   @Column({
     type: DataType.STRING(512),
     allowNull: false,


### PR DESCRIPTION
### Type of PR
- [ ] Feature
- [x] Bugfix
- [ ] Hotfix
- [ ] Chore

### Merge strategy
- [x] Squash (default)
- [ ] Merge commit (branch merges, usually used for merges to master)
- [ ] Rebase (preserve individual commits without merge commit)


### Purpose
Due to issues with the testing file to call methods of Auth Services like `AuthService.validateJWT()`, now, the JWTBlacklist model extends from Model.
The error was caused when a JWT Model Query was done, so,  debugging a little bit a solution was found to change the extends because it is redundant.
<img width="524" alt="image" src="https://user-images.githubusercontent.com/62272090/176260605-a28358c1-ccef-489a-8a5b-2c00eed10694.png">


<img width="743" alt="image" src="https://user-images.githubusercontent.com/62272090/176258122-d34afa4a-3dc4-4a0b-9d6e-96d820711842.png">

The resultis this!
<img width="461" alt="image" src="https://user-images.githubusercontent.com/62272090/176261271-cab31cca-2c8f-4714-9a98-170ba4636d18.png">
