### PR TITLE
Bug fix: baseModel now is local

### DIFF
--- a/generators/app/templates/app/libraries/BaseModel.ts
+++ b/generators/app/templates/app/libraries/BaseModel.ts
@@ -1,0 +1,13 @@
+import { Model } from "sequelize-typescript";
+
+/* 
+  BaseModel: 
+  All models inherit from this class, 
+  modify it to apply defaults to all your models.
+*/
+
+export class BaseModel<T> extends Model<T> {
+  toJSON() {
+    return super.toJSON();
+  }
+}

--- a/generators/app/templates/app/models/JWTBlacklist.ts
+++ b/generators/app/templates/app/models/JWTBlacklist.ts
@@ -1,10 +1,9 @@
 import { Table, Column, DataType, Model } from "sequelize-typescript";
-import { BaseModel } from "flugzeug";
-
+import { BaseModel } from "@/libraries/BaseModel";
 @Table({
   tableName: "jwtblacklist",
 })
-export class JWTBlacklist extends Model {
+export class JWTBlacklist extends BaseModel<JWTBlacklist> {
   @Column({
     type: DataType.STRING(512),
     allowNull: false,

--- a/generators/app/templates/app/models/JWTBlacklist.ts
+++ b/generators/app/templates/app/models/JWTBlacklist.ts
@@ -1,10 +1,10 @@
-import { Table, Column, DataType } from "sequelize-typescript";
+import { Table, Column, DataType, Model } from "sequelize-typescript";
 import { BaseModel } from "flugzeug";
 
 @Table({
   tableName: "jwtblacklist",
 })
-export class JWTBlacklist extends BaseModel<JWTBlacklist> {
+export class JWTBlacklist extends Model {
   @Column({
     type: DataType.STRING(512),
     allowNull: false,

--- a/generators/app/templates/app/models/Policy.ts
+++ b/generators/app/templates/app/models/Policy.ts
@@ -1,5 +1,5 @@
 import { Table, Column, DataType, HasMany } from "sequelize-typescript";
-import { BaseModel } from "flugzeug";
+import { BaseModel } from "@/libraries/BaseModel";
 import { RolePolicy } from "@/models/RolePolicy";
 
 export interface PermissionData {

--- a/generators/app/templates/app/models/Profile.ts
+++ b/generators/app/templates/app/models/Profile.ts
@@ -5,7 +5,7 @@ import {
   BelongsTo,
   ForeignKey,
 } from "sequelize-typescript";
-import { BaseModel } from "flugzeug";
+import { BaseModel } from "@/libraries/BaseModel";
 import { User } from "./User";
 
 @Table({

--- a/generators/app/templates/app/models/Role.ts
+++ b/generators/app/templates/app/models/Role.ts
@@ -5,7 +5,7 @@ import {
   HasMany,
   BelongsToMany,
 } from "sequelize-typescript";
-import { BaseModel } from "flugzeug";
+import { BaseModel } from "@/libraries/BaseModel";
 import { Policy } from "@/models/Policy";
 import { RolePolicy } from "@/models/RolePolicy";
 import { UserRole } from "@/models/UserRole";

--- a/generators/app/templates/app/models/RolePolicy.ts
+++ b/generators/app/templates/app/models/RolePolicy.ts
@@ -1,5 +1,5 @@
 import { Table, Column, DataType, ForeignKey } from "sequelize-typescript";
-import { BaseModel } from "flugzeug";
+import { BaseModel } from "@/libraries/BaseModel";
 import { Role } from "@/models/Role";
 import { Policy } from "@/models/Policy";
 

--- a/generators/app/templates/app/models/UserRole.ts
+++ b/generators/app/templates/app/models/UserRole.ts
@@ -1,5 +1,5 @@
 import { Table, Column, DataType, ForeignKey } from "sequelize-typescript";
-import { BaseModel } from "flugzeug";
+import { BaseModel } from "@/libraries/BaseModel";
 import { User } from "@/models/User";
 import { Role } from "@/models/Role";
 


### PR DESCRIPTION
### Type of PR
- [ ] Feature
- [x] Bugfix
- [ ] Hotfix
- [ ] Chore

### Merge strategy
- [x] Squash (default)
- [ ] Merge commit (branch merges, usually used for merges to master)
- [ ] Rebase (preserve individual commits without merge commit)


### Purpose
Due to issues with the testing file to call methods of Auth Services like `AuthService.validateJWT()`, now, the JWTBlacklist model extends from Model.
The error was caused when a JWT Model Query was done, so,  debugging a little bit a solution was found by creating a local file called BaseModel into the libraries folder and extending JWTBlacklist from it.
Furthermore, all models now extend from the local file.
<img width="659" alt="image" src="https://user-images.githubusercontent.com/62272090/176301316-cb7cc6c8-30ef-42fe-8f81-eda3e97ac463.png">


The Error!

<img width="524" alt="image" src="https://user-images.githubusercontent.com/62272090/176260605-a28358c1-ccef-489a-8a5b-2c00eed10694.png">